### PR TITLE
Creates query() with the end goal of returning free time(s) given a c…

### DIFF
--- a/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-4-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -13,11 +13,38 @@
 // limitations under the License.
 
 package com.google.sps;
-
-import java.util.Collection;
+import java.util.Collection; 
+import java.util.Collections; 
+import java.util.Set;
+import java.util.List; 
+import java.util.ArrayList; 
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    
+    Collection<TimeRange> times = new ArrayList<TimeRange>();
+    long duration = request.getDuration(); 
+    if (duration > 1440) {
+      return times;
+    }
+    else if (request.getAttendees() == null) {
+      times.add(TimeRange.fromStartDuration(0,24*60)); 
+      return times; 
+    } 
+    else {
+      for (Event event : events) {
+        TimeRange eventTR = event.getWhen();
+        TimeRange start = TimeRange.fromStartEnd(0, eventTR.start(), false);
+        if (!events.contains(eventTR) {
+          times.add(start);
+        } 
+        TimeRange end = TimeRange.fromStartEnd(eventTR.end(), 1440, false);
+        if (!events.contains(eventTR)) {
+          times.add(end); 
+        }
+      }
+    return times;
+    }
+    }
   }
-}
+


### PR DESCRIPTION
Creates query() with the end goal of returning free time(s) given a collection of events and meeting request. Currently, query() accounts for some edge cases and given an event returns availabilities directly before and after said event. 
Note: this algorithm isn't complete, I talked to Cass and I think as long as I submit a PR for week4, I should be able to complete SPS.